### PR TITLE
fix: update postcss dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@use-it/interval": "^1.0.0",
     "autoprefixer": "^9",
     "babel-plugin-macros": "^3.1.0",
-    "postcss": "^7",
+    "postcss": "^8.4.6",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",


### PR DESCRIPTION
Version 7 which was previously requested is not supported on the latest
Node. Updating to the current version resolves this problem.